### PR TITLE
Antilag refactor

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1771,7 +1771,7 @@ void ClientThink_real( gentity_t *ent ) {
 	VectorCopy( ent->client->ps.origin, ent->r.currentOrigin );
 
 	// L0 - antilag
-	G_StoreTrail(ent);
+	G_StoreTrailNode(ent);
 
 	// touch other objects
 	ClientImpacts( ent, &pm );

--- a/src/game/g_antilag.c
+++ b/src/game/g_antilag.c
@@ -206,11 +206,6 @@ void G_TimeShiftAllClients(int time, gentity_t *skip) {
 	int			i;
 	gentity_t	*ent;
 
-	// don't shift clients if the client's simulated server time is past the real server time. the client positions the server currently has will suffice.
-	if (time > level.time) {
-		return;
-	}
-
 	// don't shift clients if "skip" (the client that's trying to timeshift everyone) is more than 500ms behind the current server time (very laggy).
 	if (level.time - time > 500) {
 		return;

--- a/src/game/g_antilag.c
+++ b/src/game/g_antilag.c
@@ -35,10 +35,11 @@ the teleport bit is toggled)
 ============
 */
 void G_ResetTrail(gentity_t *ent) {
-	int	i, time, time_increment, sv_fps;
+	int	i, time;
 
-	sv_fps = trap_Cvar_VariableIntegerValue("sv_fps");
-	time_increment = sv_fps == 0 ? 50 : 1000 / sv_fps;
+	// we want to store half a second worth of trails (500ms)
+	const int trail_time_range_ms = 500;
+	const int time_increment = round((double)trail_time_range_ms / (double)NUM_CLIENT_TRAILS);
 
 	// fill up the origin trails with data (assume the current position
 	// for the last 1/2 second or so)

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -677,7 +677,6 @@ void respawn( gentity_t *ent ) {
 
 	// L0 - antilag
 	G_ResetTrail(ent);
-	ent->client->saved.leveltime = 0;
 }
 
 // NERVE - SMF - merge from team arena
@@ -2004,7 +2003,6 @@ void ClientBegin( int clientNum ) {
 
 // L0 - antilag
 	G_ResetTrail(ent);
-	ent->client->saved.leveltime = 0;
 // End
 
 	// Xian -- Changed below for team independant maxlives

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -632,12 +632,12 @@ typedef struct {
 } clientPersistant_t;
 
 // L0 - antilag 
-#define NUM_CLIENT_TRAILS 10
+#define NUM_CLIENT_TRAILS 64
 typedef struct {
 	vec3_t    mins, maxs;
 	vec3_t    currentOrigin;
-	int       time, leveltime;
-	clientAnimationInfo_t animInfo;
+	int       time;
+	clientAnimationInfo_t animationInfo;
 } clientTrail_t;
 
 #define LT_SPECIAL_PICKUP_MOD	3		// JPW NERVE # of times (minus one for modulo) LT must drop ammo before scoring a point
@@ -733,9 +733,11 @@ struct gclient_s {
 
 // L0 
 	// antilag
-	int              trailHead;
-	clientTrail_t    trail[NUM_CLIENT_TRAILS];
-	clientTrail_t    saved; 
+	int				trailHead;
+	int				last_store_trail_time;
+	int				accum_store_trail_time;
+	clientTrail_t	trail[NUM_CLIENT_TRAILS];
+	clientTrail_t	saved_trail;
 
 	// Double kill
 	int			doublekill;	

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -632,13 +632,13 @@ typedef struct {
 } clientPersistant_t;
 
 // L0 - antilag 
-#define NUM_CLIENT_TRAILS 64
+#define NUM_CLIENT_TRAIL_NODES 64
 typedef struct {
 	vec3_t    mins, maxs;
 	vec3_t    currentOrigin;
 	int       time;
 	clientAnimationInfo_t animationInfo;
-} clientTrail_t;
+} clientTrailNode_t;
 
 #define LT_SPECIAL_PICKUP_MOD	3		// JPW NERVE # of times (minus one for modulo) LT must drop ammo before scoring a point
 #define MEDIC_SPECIAL_PICKUP_MOD	4	// JPW NERVE same thing for medic
@@ -733,11 +733,11 @@ struct gclient_s {
 
 // L0 
 	// antilag
-	int				trailHead;
-	int				last_store_trail_time;
-	int				accum_store_trail_time;
-	clientTrail_t	trail[NUM_CLIENT_TRAILS];
-	clientTrail_t	saved_trail;
+	int					trail_head;
+	int					last_trail_node_store_time;
+	int					accum_trail_node_store_time;
+	clientTrailNode_t	trail[NUM_CLIENT_TRAIL_NODES];
+	clientTrailNode_t	saved_trail_node;
 
 	// Double kill
 	int			doublekill;	
@@ -1905,7 +1905,7 @@ void RemoveExpiredTempbans(void);
 // g_antilag.c
 //
 void G_ResetTrail(gentity_t *ent);
-void G_StoreTrail(gentity_t *ent);
+void G_StoreTrailNode(gentity_t *ent);
 void G_TimeShiftAllClients(int time, gentity_t *skip);
 void G_UnTimeShiftAllClients(gentity_t *skip);
 

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -334,7 +334,6 @@ void Weapon_Syringe(gentity_t *ent) {
 
 				// L0 - antilag
 				G_ResetTrail(traceEnt);
-				traceEnt->client->saved.leveltime = 0;
 
 				memcpy(traceEnt->client->ps.ammo, ammo, sizeof(int)*MAX_WEAPONS);
 				memcpy(traceEnt->client->ps.ammoclip, ammoclip, sizeof(int)*MAX_WEAPONS);


### PR DESCRIPTION
The interpolation was going in the wrong direction, that has been fixed.

There were only 10 samples (trail nodes) per client that spanned 500 ms. 125 fps clients send around ~64 usercmd packets every 500ms; so I increased the samples to 64, and rate limited trail node storage for clients > 125 fps.

Due to the added granularity, this also means there's no need to have "leveltime" checks (& snapping) anymore; so that was all removed.