### PR TITLE
missing/lost cvar g_medicAmmoPack settings in .cfg

### DIFF
--- a/assets/server/main/deathmatch.cfg
+++ b/assets/server/main/deathmatch.cfg
@@ -104,6 +104,10 @@ seta g_dropAmmoPack "0"					// Players drop ammo packs on death filled w/ howeve
 seta g_dropClips "1"                    // Drop reserve ammo
 seta g_dropReload "1"                   // Dropping then picking up weapon reloads ammo clip
 
+// Extra weapons for PC_MEDIC class (medic)
+seta g_medicAmmoPack "0"				// 1 to enable, 0 to disable. Medics have ammo packs. NOTE: This forces g_LTChargeTime to be g_medicChargeTime * 4. Otherwise animation break client-side.
+seta g_ammoPackGivesWeapon "0"				// If no primary weapon (lost it or w/e) then ammo pack will give it back.
+
 // Other weapon stuff
 seta g_allowUnderwater "1"		// Can shoot weapons underwater
 seta g_customMGs "1"                    // Allow players to use: /sten /mp40 /thompson 


### PR DESCRIPTION
quickly to enable extra weapons for PC_MEDIC class (medic) in configuration file deathmatch.cfg without fixing and compiling library code

seta g_medicAmmoPack "0"          // 1 to enable, 0 to disable. Medics have ammo packs. NOTE: This forces g_LTChargeTime to be g_medicChargeTime * 4. Otherwise animation break client-side.
seta g_ammoPackGivesWeapon "0"          // If no primary weapon (lost it or w/e) then ammo pack will give it back.